### PR TITLE
Fix typo with `!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ macro_rules! cascade {
         };
     };
     ($e: expr; $($tail: tt)*) => {
-        $crate::cascade(__tmp: $e; $($tail)*)
+        $crate::cascade!(__tmp: $e; $($tail)*)
     };
     (@line $i:ident, | $s: stmt; $($tail: tt)*) => {
         $s;


### PR DESCRIPTION
There was a typo in #6 where one of the `cascade!` macros had no `!` at the end.